### PR TITLE
Add dual aim key bind support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,9 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx4G
+
+# Use proxy upon bad network
+#systemProp.http.proxyHost=127.0.0.1
+#systemProp.http.proxyPort=7890
+#systemProp.https.proxyHost=127.0.0.1
+#systemProp.https.proxyPort=7890

--- a/src/main/java/com/tac/guns/Config.java
+++ b/src/main/java/com/tac/guns/Config.java
@@ -220,7 +220,6 @@ public class Config
     {
         public final ForgeConfigSpec.DoubleValue aimDownSightSensitivity;
 
-        public final ForgeConfigSpec.BooleanValue toggleAim;
         public final ForgeConfigSpec.IntValue toggleAimDelay;
         public final ForgeConfigSpec.BooleanValue burstPress;
         public Controls(ForgeConfigSpec.Builder builder)
@@ -229,7 +228,6 @@ public class Config
             {
                 this.aimDownSightSensitivity = builder.comment("A value to multiple the mouse sensitivity by when aiming down weapon sights. Go to (Options > Controls > Mouse Settings > ADS Sensitivity) in game to change this!").defineInRange("aimDownSightSensitivity", 0.75, 0.0, 2.0);
 
-                this.toggleAim = builder.comment("Click to toggle aim on and off in game, instead of holding your aim button, the only way to utilize the toggleAim Keybind at this point!").define("toggleAim", false);
                 this.toggleAimDelay = builder.comment("The delay in ticks before being able to activate your toggleAim again, recommended to leave alone or increase past default!").defineInRange("toggleAimDelay", 8, 1, 60);
                 this.burstPress = builder.comment("Press to use a burst fire a gun, or hold to continue a burst, un-clicking cancels your burst").define("burstPress", true);
             }

--- a/src/main/java/com/tac/guns/client/ClientHandler.java
+++ b/src/main/java/com/tac/guns/client/ClientHandler.java
@@ -81,8 +81,6 @@ import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
-import net.minecraftforge.client.event.InputEvent;
-import net.minecraftforge.client.model.obj.OBJLoader;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -235,7 +233,7 @@ public class ClientHandler
             {
                 OptionsRowList list = (OptionsRowList) mouseOptionsField.get(screen);
                 list.addOption(GunOptions.ADS_SENSITIVITY, GunOptions.CROSSHAIR);
-                list.addOption(GunOptions.TOGGLE_ADS);/*, GunOptions.BURST_MECH);*/
+                /*, GunOptions.BURST_MECH);*/
             }
             catch(IllegalAccessException e)
             {
@@ -296,22 +294,6 @@ public class ClientHandler
     	};
     	InputHandler.INSPECT.addPressCallBack( callback );
     	InputHandler.CO_INSPECT.addPressCallBack( callback );
-    }
-    @SubscribeEvent
-    public static void onKeyPressed(InputEvent.KeyInputEvent event)
-    {
-        Minecraft mc = Minecraft.getInstance();
-        if(mc.player != null && mc.currentScreen == null)
-        {
-            /*if(KeyBinds.KEY_SIGHT_SWITCH.isPressed())
-            {
-                PacketHandler.getPlayChannel().sendToServer(new MessageIronSightSwitch());
-            }*/
-            /*else if(KeyBinds.COLOR_BENCH.isPressed())
-            {
-                PacketHandler.getPlayChannel().sendToServer(new MessageColorBench());
-            }*/
-        }
     }
 
     /* Uncomment for debugging headshot hit boxes */

--- a/src/main/java/com/tac/guns/client/KeyBind.java
+++ b/src/main/java/com/tac/guns/client/KeyBind.java
@@ -6,8 +6,6 @@ import java.util.function.Function;
 
 import org.lwjgl.glfw.GLFW;
 
-import com.tac.guns.GunMod;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.client.util.InputMappings;
@@ -144,7 +142,6 @@ public final class KeyBind
 		if( code == this.keyCode ) return false;
 		
 		// Key bind has been changed, update it
-		GunMod.LOGGER.info( "key bind changed " + this.name() + ":" + this.keyCode() );
 		this.$keyCode( code );
 		this.keyBind.bind( InputMappings.INPUT_INVALID );
 		return true;

--- a/src/main/java/com/tac/guns/client/handler/ShootingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/ShootingHandler.java
@@ -1,8 +1,10 @@
 package com.tac.guns.client.handler;
 
+import org.lwjgl.glfw.GLFW;
+
 import com.tac.guns.Config;
 import com.tac.guns.GunMod;
-import com.tac.guns.client.settings.GunOptions;
+import com.tac.guns.client.InputHandler;
 import com.tac.guns.common.Gun;
 import com.tac.guns.event.GunFireEvent;
 import com.tac.guns.item.GunItem;
@@ -12,23 +14,16 @@ import com.tac.guns.network.message.MessageShoot;
 import com.tac.guns.network.message.MessageShooting;
 import com.tac.guns.util.GunEnchantmentHelper;
 import com.tac.guns.util.GunModifierHelper;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.CooldownTracker;
-import net.minecraft.util.text.TextComponent;
-import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import org.apache.logging.log4j.Level;
-import org.lwjgl.glfw.GLFW;
-
-import java.util.UUID;
-
-import static com.tac.guns.GunMod.LOGGER;
 
 /**
  * Author: Forked from MrCrayfish, continued by Timeless devs
@@ -102,15 +97,6 @@ public class  ShootingHandler
         if(player == null)
             return;
 
-        if(event.getButton() == GLFW.GLFW_MOUSE_BUTTON_RIGHT && AimingHandler.get().isLookingAtInteractableBlock())
-        {
-            if(player.getHeldItemMainhand().getItem() instanceof GunItem && !AimingHandler.get().isLookingAtInteractableBlock())
-            {
-                event.setCanceled(true);
-            }
-            return;
-        }
-
         ItemStack heldItem = player.getHeldItemMainhand();
         if(heldItem.getItem() instanceof GunItem)
         {
@@ -119,7 +105,7 @@ public class  ShootingHandler
             {
                 event.setCanceled(true);
             }
-            if(event.getAction() == GLFW.GLFW_PRESS && button == GLFW.GLFW_MOUSE_BUTTON_LEFT)
+            if( InputHandler.PULL_TRIGGER.down )
             {
                 if(heldItem.getItem() instanceof TimelessGunItem && heldItem.getTag().getInt("CurrentFireMode") == 3 && this.burstCooldown == 0)
                 {
@@ -130,7 +116,6 @@ public class  ShootingHandler
                 }
                 else if(this.burstCooldown == 0)
                     fire(player, heldItem);
-
             }
         }
     }
@@ -151,7 +136,7 @@ public class  ShootingHandler
             ItemStack heldItem = player.getHeldItemMainhand();
             if(heldItem.getItem() instanceof GunItem && (Gun.hasAmmo(heldItem) || player.isCreative()))
             {
-                boolean shooting = GLFW.glfwGetMouseButton(mc.getMainWindow().getHandle(), GLFW.GLFW_MOUSE_BUTTON_LEFT) == GLFW.GLFW_PRESS && !this.clickUp;
+                boolean shooting = InputHandler.PULL_TRIGGER.down && !this.clickUp;
                 if(GunRenderingHandler.get().sprintTransition != 0) {
                     shooting = false;
                 }
@@ -185,39 +170,6 @@ public class  ShootingHandler
         }
     }
 
-    /*@SubscribeEvent
-    public void onHandleBurstShootonKeyPressed(InputEvent.RawMouseEvent event)
-    {
-        if(!this.isInGame())
-            return;
-
-        if(event.getAction() != GLFW.GLFW_PRESS)
-            return;
-
-        Minecraft mc = Minecraft.getInstance();
-        PlayerEntity player = mc.player;
-        if(player == null)
-            return;
-        if(!Config.CLIENT.controls.burstPress.get())
-            return;
-
-        if(event.getButton() == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-            ItemStack heldItem = player.getHeldItemMainhand();
-            if (heldItem.getItem() instanceof TimelessGunItem) {
-                TimelessGunItem gunItem = (TimelessGunItem) heldItem.getItem();
-                Gun gun = gunItem.getGun();
-                if (heldItem.getTag().getInt("CurrentFireMode") == 3 && this.burstCooldown == 0)
-                {
-                //CooldownTracker tracker = player.getCooldownTracker();
-                    //if (!tracker.hasCooldown(heldItem.getItem())) {
-                        //fire(player, heldItem);
-                        this.burstTracker = gun.getGeneral().getBurstCount();
-                        this.burstCooldown = gun.getGeneral().getBurstRate();
-                    //}
-                }
-            }
-        }
-    }*/
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent event)
     {
@@ -280,7 +232,7 @@ public class  ShootingHandler
                     }*/
                     return;
                 }
-                else if(GLFW.glfwGetMouseButton(mc.getMainWindow().getHandle(), GLFW.GLFW_MOUSE_BUTTON_LEFT) == GLFW.GLFW_PRESS)
+                else if( InputHandler.PULL_TRIGGER.down )
                 {
                     Gun gun = ((TimelessGunItem) heldItem.getItem()).getModifiedGun(heldItem);
                     if (gun.getGeneral().isAuto() && heldItem.getTag().getInt("CurrentFireMode") == 2) {
@@ -311,7 +263,7 @@ public class  ShootingHandler
                     }
                     //}
                 }
-                else if(this.clickUp || GLFW.glfwGetMouseButton(mc.getMainWindow().getHandle(), GLFW.GLFW_MOUSE_BUTTON_LEFT) == GLFW.GLFW_RELEASE)
+                else if(this.clickUp || InputHandler.PULL_TRIGGER.down )
                 {
                     if(heldItem.getTag().getInt("CurrentFireMode") == 3 && this.burstTracker > 0) {
                         this.burstCooldown = gunItem.getGun().getGeneral().getBurstRate();

--- a/src/main/java/com/tac/guns/client/settings/GunOptions.java
+++ b/src/main/java/com/tac/guns/client/settings/GunOptions.java
@@ -1,19 +1,19 @@
 package com.tac.guns.client.settings;
 
+import java.text.DecimalFormat;
+
 import com.tac.guns.Config;
 import com.tac.guns.client.handler.CrosshairHandler;
 import com.tac.guns.client.render.crosshair.Crosshair;
+
 import net.minecraft.client.AbstractOption;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.AbstractGui;
-import net.minecraft.client.gui.widget.button.OptionButton;
 import net.minecraft.client.settings.BooleanOption;
 import net.minecraft.client.settings.SliderPercentageOption;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TranslationTextComponent;
-
-import java.text.DecimalFormat;
 
 /**
  * Author: Forked from MrCrayfish, continued by Timeless devs
@@ -30,13 +30,6 @@ public class GunOptions
     }, (gameSettings, option) -> {
         double adsSensitivity = Config.CLIENT.controls.aimDownSightSensitivity.get();
         return new TranslationTextComponent("tac.options.adsSensitivity.format", FORMAT.format(adsSensitivity));
-    });
-
-    public static final BooleanOption TOGGLE_ADS = new BooleanOption("tac.options.toggleAim", (settings) -> {
-        return Config.CLIENT.controls.toggleAim.get();
-    }, (settings, value) -> {
-        Config.CLIENT.controls.toggleAim.set(value);
-        Config.saveClientConfig();
     });
 
    /* public static final BooleanOption BURST_MECH = new BooleanOption("tac.options.burstPress", (settings) -> {


### PR DESCRIPTION
Issue found: The original TAC implementation to prevent the gun from destroying the block and bobbing on use is to simply cancel the raw mouse input event. That is kind of too rough to handle this issue. Actually there exists methods that can be override in Item class which can be used to define the behavior of the item on mouse click. It will be better if it is possible to give a refactor on it.