### PR TITLE
add ISTER rendering method on RenderUtil

### DIFF
--- a/src/main/java/com/tac/guns/client/render/gun/ModelOverrides.java
+++ b/src/main/java/com/tac/guns/client/render/gun/ModelOverrides.java
@@ -121,7 +121,8 @@ public class ModelOverrides
         }
     }
 
-    private static class ISTERModelOverride implements IOverrideModel{
+    public static class ISTERModelOverride implements IOverrideModel{
+
         @Override
         public void render(float partialTicks, ItemCameraTransforms.TransformType transformType, ItemStack stack, ItemStack parent, LivingEntity entity, MatrixStack matrixStack, IRenderTypeBuffer buffer, int light, int overlay) {
             RenderUtil.renderISTER(ModelOverrides.getISTERRenderer(stack), transformType, stack, matrixStack, buffer, light, overlay);

--- a/src/main/java/com/tac/guns/client/util/RenderUtil.java
+++ b/src/main/java/com/tac/guns/client/util/RenderUtil.java
@@ -196,7 +196,7 @@ public class RenderUtil
     /*
     * for ISTER rendering on special models. (EG; Geckolib Item Renderer)
      */
-    public static void renderModel(ItemStackTileEntityRenderer renderer, ItemCameraTransforms.TransformType transformType, ItemStack stack, MatrixStack matrixStack, IRenderTypeBuffer buffer, int light, int overlay)
+    public static void renderISTER(ItemStackTileEntityRenderer renderer, ItemCameraTransforms.TransformType transformType, ItemStack stack, MatrixStack matrixStack, IRenderTypeBuffer buffer, int light, int overlay)
     {
         if(!stack.isEmpty())
         {

--- a/src/main/java/com/tac/guns/client/util/RenderUtil.java
+++ b/src/main/java/com/tac/guns/client/util/RenderUtil.java
@@ -20,6 +20,7 @@ import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.model.ModelResourceLocation;
+import net.minecraft.client.renderer.tileentity.ItemStackTileEntityRenderer;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.inventory.container.PlayerContainer;
 import net.minecraft.item.*;
@@ -188,6 +189,20 @@ public class RenderUtil
                 stack.getItem().getItemStackTileEntityRenderer().func_239207_a_(stack, transformType, matrixStack, buffer, light, overlay);
             }
 
+            matrixStack.pop();
+        }
+    }
+
+    /*
+    * for ISTER rendering on special models. (EG; Geckolib Item Renderer)
+     */
+    public static void renderModel(ItemStackTileEntityRenderer renderer, ItemCameraTransforms.TransformType transformType, ItemStack stack, MatrixStack matrixStack, IRenderTypeBuffer buffer, int light, int overlay)
+    {
+        if(!stack.isEmpty())
+        {
+            matrixStack.push();
+            matrixStack.translate(-0.5D, -0.5D, -0.5D);
+            renderer.func_239207_a_(stack, transformType, matrixStack, buffer, light, overlay);
             matrixStack.pop();
         }
     }


### PR DESCRIPTION
this allows user to directly render instance of ItemStackTileEntityRenderer on Modeloverride.
this method should make addon developers easier to have much more freedom on model such as geckolib while keeping 2D texture on GUI.